### PR TITLE
Add rrq dashboard

### DIFF
--- a/bin/reverse-proxy
+++ b/bin/reverse-proxy
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
 set -eu
 
-if [ "$#" -eq 6 ]; then
+if [ "$#" -eq 7 ]; then
     export PROMETHEUS_SERVICE=$1
     export ALERTMANAGER_SERVICE=$2
     export GRAFANA_SERVICE=$3
-    export HTTP_HOST=$4
-    export HTTP_PORT=$5
-    export HTTPS_PORT=$6
+    export RRQ_DASHBOARD_SERVICE=$4
+    export HTTP_HOST=$5
+    export HTTP_PORT=$6
+    export HTTPS_PORT=$7
 else
-    echo "Usage: <prometheus-service> <alertmanager-service> <grafana-service> <hostname> <port-http> <port-https>"
-    echo "e.g. docker run ... container:8888 container2:8889 container3:8890 example.com 80 443"
+    echo "Usage: <prometheus-service> <alertmanager-service> <grafana-service> <rrq-dashboard-service> <hostname> <port-http> <port-https>"
+    echo "e.g. docker run ... container:8888 container2:8889 container3:8890 container4:8891 example.com 80 443"
     exit 1
 fi
 
 echo "We will listen on ports $HTTP_PORT (http) and $HTTPS_PORT (https)"
-echo "with hostname $HTTP_HOST, proxying the services http://$PROMETHEUS_SERVICE http://$ALERTMANAGER_SERVICE http://$GRAFANA_SERVICE"
+echo "with hostname $HTTP_HOST, proxying the services http://$PROMETHEUS_SERVICE http://$ALERTMANAGER_SERVICE http://$GRAFANA_SERVICE http://$RRQ_DASHBOARD_SERVICE"
 
-envsubst '$HTTP_HOST,$HTTP_PORT,$HTTPS_PORT,$PROMETHEUS_SERVICE,$ALERTMANAGER_SERVICE,$GRAFANA_SERVICE' \
+envsubst '$HTTP_HOST,$HTTP_PORT,$HTTPS_PORT,$PROMETHEUS_SERVICE,$ALERTMANAGER_SERVICE,$GRAFANA_SERVICE,$RRQ_DASHBOARD_SERVICE' \
          < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 # These paths must match the paths as used in the nginx.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -105,6 +105,10 @@ http {
             proxy_set_header Host $http_host;
             proxy_pass http://${GRAFANA_SERVICE};
         }
+
+        location /rrq/ {
+            proxy_pass http://${RRQ_DASHBOARD_SERVICE};
+        }
     }
 
     # Redirect all http requests to the SSL endpoint and the correct domain name


### PR DESCRIPTION
This adds a new `/rrq` endpoint, which forwards to yet another container, which runs https://github.com/reside-ic/rrq.dashboard/.